### PR TITLE
Update dropbox_api to 0.1.18

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     activestorage-dropbox (1.0.0)
-      dropbox_api (~> 0.1.16)
+      dropbox_api (~> 0.1.18)
 
 GEM
   remote: https://rubygems.org/
@@ -60,18 +60,18 @@ GEM
     crass (1.0.4)
     diff-lcs (1.3)
     docile (1.3.1)
-    dropbox_api (0.1.16)
-      faraday (>= 0.8, <= 0.15.4)
+    dropbox_api (0.1.18)
+      faraday (<= 1.0)
       oauth2 (~> 1.1)
     erubi (1.8.0)
-    faraday (0.15.4)
+    faraday (1.0.0)
       multipart-post (>= 1.2, < 3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     json (2.2.0)
-    jwt (2.1.0)
+    jwt (2.2.1)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -84,14 +84,14 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    multi_json (1.13.1)
+    multi_json (1.14.1)
     multi_xml (0.6.0)
-    multipart-post (2.0.0)
+    multipart-post (2.1.1)
     nio4r (2.3.1)
     nokogiri (1.10.2)
       mini_portile2 (~> 2.4.0)
-    oauth2 (1.4.1)
-      faraday (>= 0.8, < 0.16.0)
+    oauth2 (1.4.4)
+      faraday (>= 0.8, < 2.0)
       jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
@@ -172,4 +172,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.0.1
+   2.1.2

--- a/activestorage-dropbox.gemspec
+++ b/activestorage-dropbox.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "coveralls", "~> 0.8.22"  
+  spec.add_development_dependency "coveralls", "~> 0.8.22"
   spec.add_development_dependency "rails", ">= 5.2"
 
-  spec.add_dependency "dropbox_api", "~> 0.1.16"  
+  spec.add_dependency "dropbox_api", "~> 0.1.18"
 end


### PR DESCRIPTION
In this pull request, I updated the `dropbox_api` gem to the latest version. I think it is important because this is the heart of this gem.

Obs: I did a test in a personal project using a gem with the dropbox_api new version and everything ran ok.