### PR TITLE
Add custom_metadata keyword to upload method signature to match Rails 7 requirements

### DIFF
--- a/lib/active_storage/service/dropbox_service.rb
+++ b/lib/active_storage/service/dropbox_service.rb
@@ -10,7 +10,7 @@ module ActiveStorage
       @config = config
     end
 
-    def upload(key, io, checksum: nil, content_type: nil, disposition: nil, filename: nil)
+    def upload(key, io, checksum: nil, filename: nil, content_type: nil, disposition: nil, custom_metadata: {})
       instrument :upload, key: key, checksum: checksum do
         client.upload_by_chunks "/"+key, io
       rescue DropboxApi::Errors::UploadError
@@ -24,7 +24,7 @@ module ActiveStorage
           stream(key, &block)
         end
       else
-        instrument :download, key: key do 
+        instrument :download, key: key do
           download_for(key)
         rescue DropboxApi::Errors::NotFoundError
           raise ActiveStorage::FileNotFoundError
@@ -62,7 +62,7 @@ module ActiveStorage
 
     def url(key, expires_in:, filename:, disposition:, content_type:)
       instrument :url, key: key do |payload|
-        generated_url = file_for(key).link 
+        generated_url = file_for(key).link
         payload[:url] = generated_url
         generated_url
       end


### PR DESCRIPTION
## TL;DR
Fixes a bug in uploading images for Rails 7.

## Explanation
I recently updated one of my apps from Rails 6.1.7 to Rails 7.0.4.3 and in doing so, broke my ability to upload images to Dropbox via ActiveStorage. I was able to trace the error back to the upload method here in this gem:

```
ArgumentError: unknown keyword: :custom_metadata
from /Users/myusername/.rvm/gems/ruby-3.1.0/gems/activestorage-dropbox-1.0.0/lib/active_storage/service/dropbox_service.rb:13:in `upload'
```

That lead me to believe that somewhere Rails is expecting this method to have that argument. After doing some digging in the [ActiveStorage source code](https://github.com/rails/rails/search?q=custom_metadata), I noticed that the Rails-supported uploader services have a keyword argument `:custom_metadata` in their method signatures that conveniently matches the one in the error output. 

```ruby
# activestorage/lib/active_storage/service/s3_service.rb
def upload(key, io, checksum: nil, filename: nil, content_type: nil, disposition: nil, custom_metadata: {}, **)

# activestorage/lib/active_storage/service/gcs_service.rb
def upload(key, io, checksum: nil, content_type: nil, disposition: nil, filename: nil, custom_metadata: {})

# activestorage/lib/active_storage/service/azure_storage_service.rb
def upload(key, io, checksum: nil, filename: nil, content_type: nil, disposition: nil, custom_metadata: {}, **)
```

Adding this argument to the local copy of the gem on my machine seems to have fixed the glitch. 

## Testing 
1. in `development.rb`, change `config.active_storage.service` from `:local` to :dropbox`
1. add this argument to my local copy of the gem
1. restart my localhost:3000 server
1. step through the process that originally revealed the bug -- this time, the upload worked
1. check my dropbox folder to ensure the image was there and it was

## Code Choices
* I did not bump the version number of the gem because I saw no trend of that in previous pull requests.
* I did not add tests for this because there were no existing tests for this method.
* I reordered the args to match the Rails-supported services' signatures -- which is not important, just a preference.